### PR TITLE
Skip un-handled reportReward task init

### DIFF
--- a/src/client/component/demonware.cpp
+++ b/src/client/component/demonware.cpp
@@ -489,6 +489,8 @@ namespace demonware
 			utils::hook::call(0x141EC458C_g, get_ffotd_name); // Return unlocalized ffotd name
 			utils::hook::set<uint64_t>(0x141F04550_g, 0xC300000001B8); // Kill LPC_File_SafeWrite
 			utils::hook::set<uint64_t>(0x141F03180_g, 0xC300000001B8); // Kill LPC_DeleteStale
+			
+			utils::hook::set<uint8_t>(0x141E0AAAB_g, 0xEB); // Release un-handled reportReward spamming loop
 		}
 
 		void pre_destroy() override


### PR DESCRIPTION
shitty fix for un-handled reportReward task with action name get_user_periodic_rarities; purpose unknown 

it retries for ever untill it gets valid response from server and shapes a massive dw task spam if not disabled

