### PR TITLE
Fixes zombies intro & client sided issues with dedicated servers

### DIFF
--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -171,6 +171,12 @@ namespace party
 
 			scheduler::once([=]
 			{
+				if (is_connecting_to_dedi)
+				{
+					game::Com_SessionMode_SetGameMode(game::MODE_GAME_DEFAULT);
+					game::Com_GametypeSettings_SetGametype(gametype.data(), false, false);
+				}
+
 				//connect_to_session(target, hostname, xuid, mode);
 				connect_to_lobby_with_mode(target, mode, mapname, gametype);
 			}, scheduler::main);

--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -34,34 +34,10 @@ namespace party
 			return server_queries;
 		}
 
-		void stop_zombies_intro_if_needed()
-		{
-			if (game::Com_SessionMode_GetMode() != game::MODE_ZOMBIES)
-			{
-				return;
-			}
-
-			scheduler::once([]
-			{
-				scheduler::schedule([]
-				{
-					if (!game::Sys_IsDatabaseReady())
-					{
-						return scheduler::cond_continue;
-					}
-
-					game::Cinematic_StopPlayback(0, true);
-					return scheduler::cond_end;
-				}, scheduler::main);
-			}, scheduler::main, 15s);
-		}
-
 		void connect_to_lobby(const game::netadr_t& addr, const std::string& mapname, const std::string& gamemode)
 		{
 			game::XSESSION_INFO info{};
 			game::CL_ConnectFromLobby(0, &info, &addr, 1, 0, mapname.data(), gamemode.data(), nullptr);
-
-			stop_zombies_intro_if_needed();
 		}
 
 		void launch_mode(const game::eModes mode)

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -22,7 +22,9 @@ namespace game
 	WEAK symbol<void(const char* file, int line, int code, const char* fmt, ...)> Com_Error_{0x1420F8BD0};
 	WEAK symbol<bool(eModes mode)> Com_SessionMode_IsMode{0x1420F7DD0};
 	WEAK symbol<void(eNetworkModes networkMode)> Com_SessionMode_SetNetworkMode{0x1420F8010, 0x140500B80};
-	WEAK symbol<eGameModes(eGameModes gameMode)> Com_SessionMode_SetGameMode{0x0, 0x140500B40};
+	WEAK symbol<eGameModes(eGameModes gameMode)> Com_SessionMode_SetGameMode{0x1420F7FD0, 0x140500B40};
+	WEAK symbol<eModes(eModes mode)> Com_SessionMode_SetMode{0x1420F7FF0};
+	WEAK symbol<void(const char* gametype, bool loadDefaultSettings, bool isModified)> Com_GametypeSettings_SetGametype{0x1420F63E0};
 	WEAK symbol<bool()> Com_IsRunningUILevel{0x142148DB0};
 	WEAK symbol<void(int localClientNum, eModes fromMode, eModes toMode, uint32_t flags)> Com_SwitchMode{
 		0x14214AF30


### PR DESCRIPTION
- This should fix issues with dedicated servers rotating through different maps because players are forced to watch the intro during map rotation.
- Classes should now be previewed correctly all the time.
- Choosing different gametypes on dedicated servers / private matches, should no longer cause any issues anymore.