### PR TITLE
feat: remove color prefixes from server name in console title

### DIFF
--- a/src/client/component/dedicated_info.cpp
+++ b/src/client/component/dedicated_info.cpp
@@ -16,8 +16,8 @@ namespace dedicated_info
 		void set_server_info_in_console_title()
 		{
 			const auto sv_running = game::Dvar_FindVar("sv_running");
-			const auto server_name = game::get_dvar_string("live_steam_server_name");
-			const auto clean_server_name = game::I_CleanStr(server_name.data());
+			auto server_name = game::get_dvar_string("live_steam_server_name");
+			auto clean_server_name = game::I_CleanStr(server_name.data());
 
 			if (!sv_running || !sv_running->current.enabled)
 			{

--- a/src/client/component/dedicated_info.cpp
+++ b/src/client/component/dedicated_info.cpp
@@ -17,17 +17,18 @@ namespace dedicated_info
 		{
 			const auto sv_running = game::Dvar_FindVar("sv_running");
 			const auto server_name = game::get_dvar_string("live_steam_server_name");
+			const auto clean_server_name = game::I_CleanStr(server_name.data());
 
 			if (!sv_running || !sv_running->current.enabled)
 			{
-				console::set_title(server_name + " - not running");
+				console::set_title(utils::string::va("%s - not running", clean_server_name));
 				return;
 			}
 
 			const auto mapname = game::get_dvar_string("mapname");
 
 			const std::string window_text = utils::string::va("%s on %s [%d/%d] (%d)",
-			                                                  server_name.data(),
+															  clean_server_name,
 			                                                  mapname.data(),
 			                                                  getinfo::get_client_count(),
 			                                                  getinfo::get_max_client_count(),

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -131,6 +131,9 @@ namespace game
 	WEAK symbol<void(client_s* cl_0, svscmd_type type, const char* fmt, ...)> SV_SendServerCommand{0x0, 0x140537F10};
 	WEAK symbol<bool(int clientNum)> SV_IsTestClient{0x14224B5C0, 0x14052FF40};
 
+	// Utils
+	WEAK symbol<const char* (const char* str)> I_CleanStr{ 0x1422E9C10, 0x140580E80 };
+
 	// Variables
 
 	WEAK symbol<cmd_function_s> cmd_functions{0x15689FF58, 0x14946F860};

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -132,7 +132,7 @@ namespace game
 	WEAK symbol<bool(int clientNum)> SV_IsTestClient{0x14224B5C0, 0x14052FF40};
 
 	// Utils
-	WEAK symbol<const char* (const char* str)> I_CleanStr{ 0x1422E9C10, 0x140580E80 };
+	WEAK symbol<const char* (const char* str)> I_CleanStr{0x1422E9C10, 0x140580E80};
 
 	// Variables
 

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -132,7 +132,7 @@ namespace game
 	WEAK symbol<bool(int clientNum)> SV_IsTestClient{0x14224B5C0, 0x14052FF40};
 
 	// Utils
-	WEAK symbol<const char* (const char* str)> I_CleanStr{0x1422E9C10, 0x140580E80};
+	WEAK symbol<const char* (char* str)> I_CleanStr{0x1422E9C10, 0x140580E80};
 
 	// Variables
 


### PR DESCRIPTION
removes colored prefixes from server name when updating console title.

Old:
![image](https://user-images.githubusercontent.com/13552261/221162732-e9f95e69-3102-4836-94e0-01051d0cb6bb.png)


New:
![image](https://user-images.githubusercontent.com/13552261/221162743-bf194ef9-a5a8-4778-b757-c8f31deeca37.png)
