### PR TITLE
Lock game modes that are not installed

### DIFF
--- a/src/client/steam/interfaces/apps.cpp
+++ b/src/client/steam/interfaces/apps.cpp
@@ -33,14 +33,18 @@ namespace steam
 		return "english";
 	}
 
+	// This is used for checking DLC too.
 	bool apps::BIsSubscribedApp(unsigned int appID)
 	{
-		return true;
+		return appID == 366842 ? std::filesystem::exists("zone/zm_common.xpak")	//zombies
+			: appID == 366841 ? std::filesystem::exists("zone/mp_common.xpak")	//multiplayer
+			: appID == 366840 ? std::filesystem::exists("zone/cp_common.xpak")	//campaign
+			: true;
 	}
 
 	bool apps::BIsDlcInstalled(unsigned int appID)
 	{
-		return true;
+		return BIsSubscribedApp(appID);	//to not repeat the same code here
 	}
 
 	unsigned int apps::GetEarliestPurchaseUnixTime(unsigned int nAppID)

--- a/src/client/steam/interfaces/apps.cpp
+++ b/src/client/steam/interfaces/apps.cpp
@@ -38,9 +38,9 @@ namespace steam
 
 	bool apps::BIsSubscribedApp(unsigned int appID)
 	{
-		static const auto has_campaign = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/cp_common.xpak");
-		static const auto has_multiplayer = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/mp_common.xpak");
-		static const auto has_zombies = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/zm_common.xpak");
+		static const auto has_campaign = std::filesystem::exists(::utils::nt::library{}.get_folder() / "zone/cp_common.xpak");
+		static const auto has_multiplayer = std::filesystem::exists(::utils::nt::library{}.get_folder() / "zone/mp_common.xpak");
+		static const auto has_zombies = std::filesystem::exists(::utils::nt::library{}.get_folder() / "zone/zm_common.xpak");
 		return appID == 366840 ? has_campaign
 			: appID == 366841 ? has_multiplayer
 			: appID == 366842 ? has_zombies

--- a/src/client/steam/interfaces/apps.cpp
+++ b/src/client/steam/interfaces/apps.cpp
@@ -1,4 +1,7 @@
 #include <std_include.hpp>
+
+#include <utils/nt.hpp>
+
 #include "../steam.hpp"
 
 namespace steam
@@ -33,18 +36,20 @@ namespace steam
 		return "english";
 	}
 
-	// This is used for checking DLC too.
 	bool apps::BIsSubscribedApp(unsigned int appID)
 	{
-		return appID == 366842 ? std::filesystem::exists("zone/zm_common.xpak")	//zombies
-			: appID == 366841 ? std::filesystem::exists("zone/mp_common.xpak")	//multiplayer
-			: appID == 366840 ? std::filesystem::exists("zone/cp_common.xpak")	//campaign
+		static const auto has_campaign = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/cp_common.xpak");
+		static const auto has_multiplayer = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/mp_common.xpak");
+		static const auto has_zombies = std::filesystem::exists(::utils::nt::library{}.get_path() / "zone/zm_common.xpak");
+		return appID == 366840 ? has_campaign
+			: appID == 366841 ? has_multiplayer
+			: appID == 366842 ? has_zombies
 			: true;
 	}
 
 	bool apps::BIsDlcInstalled(unsigned int appID)
 	{
-		return BIsSubscribedApp(appID);	//to not repeat the same code here
+		return BIsSubscribedApp(appID);
 	}
 
 	unsigned int apps::GetEarliestPurchaseUnixTime(unsigned int nAppID)


### PR DESCRIPTION
This prevents an infinite loading screen caused by starting a game mode that is not installed.

![image](https://user-images.githubusercontent.com/33550839/221361987-0d894892-30fb-4120-80cb-68bd70f39049.png)

*this does not prevent the game from crashing when joining a server for a non-installed game mode through Server Browser