### PR TITLE
Potential fix dedicated servers loading offline classes

### DIFF
--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -48,6 +48,13 @@ namespace game
 		MODE_NETWORK_INVALID = 0x3,
 	};
 
+	enum MapPreload
+	{
+		MAP_PRELOAD_NONE = 0x0,
+		MAP_PRELOAD_FRONTEND = 0x1,
+		MAP_PRELOAD_IN_GAME = 0x2,
+	};
+
 	enum bdLobbyErrorCode
 	{
 		BD_NO_ERROR = 0x0,

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -130,6 +130,7 @@ namespace game
 	WEAK symbol<void*()> SV_AddTestClient{0x1422499A0, 0x14052E3E0};
 	WEAK symbol<void(client_s* cl_0, svscmd_type type, const char* fmt, ...)> SV_SendServerCommand{0x0, 0x140537F10};
 	WEAK symbol<bool(int clientNum)> SV_IsTestClient{0x14224B5C0, 0x14052FF40};
+	WEAK symbol<void(int controllerIndex, const char* server, MapPreload preload, bool savegame)> SV_SpawnServer{0x142253320, 0x140535B20};
 
 	// Utils
 	WEAK symbol<const char* (char* str)> I_CleanStr{0x1422E9C10, 0x140580E80};


### PR DESCRIPTION
I think that something overrides these modes sometimes causing dedis to load the offline classes.
So setting these online modes everytime before SV_SpawnServer gets called should fix this.