### PR TITLE
Client side progression when mods loaded + small changes for ranked dedis

### DIFF
--- a/src/client/component/client_patches.cpp
+++ b/src/client/component/client_patches.cpp
@@ -69,6 +69,43 @@ namespace client_patches
 		{
 			return MMSYSERR_NODRIVER;
 		}
+
+		bool is_mod_loaded_stub()
+		{
+			return false;
+		}
+
+		void patch_is_mod_loaded_checks()
+		{
+			const std::vector<uintptr_t> is_mod_loaded_addresses =
+			{
+				{ 0x1420F7484_g },
+				{ 0x1420F74A4_g },
+				{ 0x1420F73E4_g },
+				{ 0x1420F73B4_g },
+				{ 0x1420F6E57_g },
+				{ 0x1413E6A54_g },
+				{ 0x1415E7EBB_g },
+				{ 0x1415E87BB_g },
+				{ 0x1415EBAC9_g },
+				{ 0x1415F1F09_g },
+				{ 0x1415F1FB9_g },
+				{ 0x1415F2080_g },
+				{ 0x1415F7F40_g },
+				{ 0x141A8D0ED_g },
+				{ 0x141AA70F9_g },
+				{ 0x141EA06FB_g },
+				{ 0x141EA8C7E_g },
+				{ 0x141EB1A39_g },
+				{ 0x141ECBA9D_g },
+				{ 0x1420F6E1D_g },
+			};
+
+			for (const auto& address : is_mod_loaded_addresses)
+			{
+				utils::hook::call(address, is_mod_loaded_stub);
+			}
+		}
 	}
 
 	class component final : public client_component
@@ -82,6 +119,10 @@ namespace client_patches
 			utils::hook::set(0x15AAE9254_g, mixer_open_stub);
 
 			preload_map_hook.create(0x14135A1E0_g, preload_map_stub);
+
+			// Keep client ranked when mod loaded
+			utils::hook::jump(0x1420D5BA0_g, is_mod_loaded_stub);
+			patch_is_mod_loaded_checks();
 		}
 	};
 }

--- a/src/client/component/dedicated_patches.cpp
+++ b/src/client/component/dedicated_patches.cpp
@@ -36,7 +36,7 @@ namespace dedicated_patches
 		{
 			const std::vector<uintptr_t> is_mod_loaded_addresses =
 			{
-				{ 0x1401DA1B5_g },
+				{ 0x14019CFC4_g },
 				{ 0x14024D4A0_g },
 				{ 0x14024D669_g },
 				{ 0x14024D939_g },
@@ -47,12 +47,11 @@ namespace dedicated_patches
 				{ 0x140251E9E_g },
 				{ 0x140253680_g },
 				{ 0x140257BF6_g },
-				{ 0x1402D25E2_g }, // unsure if needed to patch
-				{ 0x1402D296D_g }, // unsure
-				{ 0x1402D58E9_g }, // unsure
-				{ 0x1402DC5BB_g }, // unsure
+				{ 0x1402D296D_g },
+				{ 0x1402D58E9_g },
 				{ 0x140468374_g },
-				{ 0x14046B796_g }
+				{ 0x14046B796_g },
+				{ 0x14048003D_g },
 			};
 
 			for (const auto& address : is_mod_loaded_addresses)


### PR DESCRIPTION
- This PR makes it able for players to level up when they have mods/usermaps loaded.
- Also changed some addresses for dedis since not everything was needed, and i forgot a few things related to challenges I assume.