### PR TITLE
Add usermap support

### DIFF
--- a/src/client/component/workshop.cpp
+++ b/src/client/component/workshop.cpp
@@ -1,0 +1,89 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+#include "workshop.hpp"
+
+#include "game/game.hpp"
+
+#include <utils/hook.hpp>
+
+namespace workshop
+{
+	const std::string get_usermap_publisher_id(const std::string& mapname)
+	{
+		const auto total_usermaps = *reinterpret_cast<unsigned int*>(0x1567B3580_g);
+
+		for (unsigned int i = 0; i < total_usermaps; ++i)
+		{
+			const auto usermap_data = reinterpret_cast<game::workshop_data*>(0x1567B3588_g + (sizeof(game::workshop_data) * i));
+			if (usermap_data->folderName == mapname)
+			{
+				return usermap_data->publisherId;
+			}
+		}
+
+		return "";
+	}
+
+	bool check_valid_publisher_id(const std::string& mapname, const std::string& pub_id)
+	{
+		if (!game::DB_FileExists(mapname.data(), 0) && pub_id.empty())
+		{
+			game::Com_Error(0, "Can't find usermap: %s!\nMake sure you're subscribed to the workshop item.", mapname.data());
+			return false;
+		}
+
+		return true;
+	}
+
+	void load_usermap_mod_if_needed(const std::string& pub_id)
+	{
+		if (!game::isModLoaded() && !pub_id.empty())
+		{
+			game::loadMod(0, "usermaps", 0);
+		}
+	}
+
+	namespace
+	{
+		utils::hook::detour setup_server_map_hook;
+
+		void setup_server_map_stub(int localClientNum, const char* mapname, const char* gametype)
+		{
+			const auto publisher_id = get_usermap_publisher_id(mapname);
+			load_usermap_mod_if_needed(publisher_id);
+
+			setup_server_map_hook.invoke(localClientNum, mapname, gametype);
+		}
+
+		bool has_workshop_item_stub(int type, const char* mapname, int a3)
+		{
+			const auto publisher_id = get_usermap_publisher_id(mapname);
+			const auto name = publisher_id.empty() ? mapname : publisher_id.data();
+
+			return utils::hook::invoke<bool>(0x1420D6380_g, type, name, a3);
+		}
+
+		game::workshop_data* load_usermap_stub(const char* mapname)
+		{
+			const auto publisher_id = get_usermap_publisher_id(mapname);
+			const auto name = publisher_id.empty() ? mapname : publisher_id.data();
+
+			return utils::hook::invoke<game::workshop_data*>(0x1420D5700_g, name);
+		}
+	}
+
+	class component final : public client_component
+	{
+	public:
+		void post_unpack() override
+		{
+			setup_server_map_hook.create(0x14135CD20_g, setup_server_map_stub);
+
+			// Allow client to switch maps if server sends zone name instead of publisher id
+			utils::hook::call(0x14135CD84_g, has_workshop_item_stub);
+			utils::hook::call(0x14135CE48_g, load_usermap_stub);
+		}
+	};
+}
+
+REGISTER_COMPONENT(workshop::component)

--- a/src/client/component/workshop.hpp
+++ b/src/client/component/workshop.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace workshop
+{
+	const std::string get_usermap_publisher_id(const std::string& mapname);
+	bool check_valid_publisher_id(const std::string& mapname, const std::string& pub_id);
+	void load_usermap_mod_if_needed(const std::string& pub_id);
+}

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -1584,6 +1584,31 @@ namespace game
 
 	static_assert(sizeof(gentity_s) == 0x4F8);
 
+	enum workshop_type
+	{
+		WORKSHOP_MOD = 0x1,
+		WORKSHOP_USERMAP = 0x2
+	};
+
+	struct workshop_data
+	{
+		char title[100];
+		char folderName[32];
+		char publisherId[32];
+		char description[256];
+		char contentPathToZoneFiles[260];
+		char absolutePathContentFolder[260];
+		char absolutePathZoneFiles[260];
+		int unk; // 1
+		int unk2; // 0
+		unsigned int publisherIdInteger;
+		int unk3;
+		unsigned int unk4;
+		workshop_type type;
+	};
+
+	static_assert(sizeof(workshop_data) == 0x4C8);
+
 	union XAssetHeader
 	{
 		/*PhysPreset* physPreset;

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -59,6 +59,8 @@ namespace game
 		0x141420ED0, 0x1401D5FB0
 	};
 	WEAK symbol<const char*(const XAsset* asset)> DB_GetXAssetName{0x1413E9DA0, 0x14019F080};
+	WEAK symbol<bool(const char* zoneName, int source)> DB_FileExists{0x141420B40};
+	WEAK symbol<void()> DB_ReleaseXAssets{0x1414247C0};
 
 	// Live
 	WEAK symbol<bool(uint64_t, int*, bool)> Live_GetConnectivityInformation{0x141E0C380};
@@ -80,6 +82,9 @@ namespace game
 
 	// Unnamed
 	WEAK symbol<const char* (const char* name)> CopyString{0x1422AC220, 0x14056BD70};
+
+	WEAK symbol<bool()> isModLoaded{0x1420D5020};
+	WEAK symbol<void(int, const char*, int)> loadMod{0x1420D6930};
 
 	// Dvar
 	WEAK symbol<bool(const dvar_t* dvar)> Dvar_IsSessionModeBaseDvar{0x1422C23A0, 0x140576890};


### PR DESCRIPTION
This PR allows clients to connect to dedicated servers/hosts that are running usermaps. 

Small side note -> switching from usermap back to a normal map causes a client/server index mismatch with zombie dedicated servers since I assume client does not unload the "usermap mod" fastfiles for some reason. I did not succeed to fix that issue so far. But It should not be a major issue atm. Client just needs to reconnect to server.

The other way around works just fine, same goes for switching between usermaps.

For now it also just throws a com_error when a user does not have an usermap installed.

This should solve #306 
