### PR TITLE
bdProfiles service

### DIFF
--- a/src/client/game/demonware/data_types.hpp
+++ b/src/client/game/demonware/data_types.hpp
@@ -505,4 +505,26 @@ namespace demonware
 			buffer->read_uint32(&this->m_maxPlayers);
 		}
 	};
+
+	class bdPublicProfileInfo final : public bdTaskResult
+	{
+	public:
+		uint64_t m_entityID;
+		int32_t m_VERSION;
+		std::string m_ddl;
+
+		void serialize(byte_buffer* buffer) override
+		{
+			buffer->write_uint64(this->m_entityID);
+			buffer->write_int32(this->m_VERSION);
+			buffer->write_blob(this->m_ddl);
+		}
+
+		void deserialize(byte_buffer* buffer) override
+		{
+			buffer->read_uint64(&this->m_entityID);
+			buffer->read_int32(&this->m_VERSION);
+			buffer->read_blob(&this->m_ddl);
+		}
+	};
 }


### PR DESCRIPTION
fixes profile customization lockout(calling card and emblem only?)

Not tested on public games but clearly others players still wont see real info since your dw server is emulated locally and does not provide connectivity between players.

in case you want to adopt it with your system, basically one way might be somehow merging it with any of ddl's shared with dedicated servers; not so familiar with how it works.