### PR TITLE
Dvar patches

### DIFF
--- a/src/client/component/dvars.cpp
+++ b/src/client/component/dvars.cpp
@@ -2,12 +2,11 @@
 #include "loader/component_loader.hpp"
 
 #include "game/game.hpp"
+#include "scheduler.hpp"
 
 #include <utils/hook.hpp>
 #include <utils/io.hpp>
 #include <utils/string.hpp>
-
-#include "scheduler.hpp"
 
 namespace dvars
 {
@@ -114,12 +113,6 @@ namespace dvars
 			{
 				return false;
 			}
-
-			//TODO: Fix archive dvars not stripping names from registered dvars
-			if (dvar->debugName == "cg_unlockall_loot"s || dvar->debugName == "cg_unlockall_purchases"s || dvar->debugName == "cg_unlockall_attachments"s || dvar->debugName == "cg_unlockall_camos"s)
-			{
-				return true;
-			}
 			
 			return (dvar->flags & game::DVAR_ARCHIVE);
 		}
@@ -217,6 +210,8 @@ namespace dvars
 			utils::hook::nop(game::select(0x142152227, 0x140509797), 6);
 			// Show all dvars in dvardump command
 			utils::hook::nop(game::select(0x142151BF9, 0x140509179), 6);
+			// Stops game from deleting debug names from archive dvars
+			utils::hook::set<uint8_t>(game::select(0x1422C5DE0, 0x1405786D0), 0xC3);
 		}
 	};
 }

--- a/src/client/component/dvars.cpp
+++ b/src/client/component/dvars.cpp
@@ -194,7 +194,7 @@ namespace dvars
 		{
 			if (!game::is_server())
 			{
-				scheduler::once(read_archive_dvars, scheduler::pipeline::main);
+				scheduler::once(read_archive_dvars, scheduler::pipeline::dvars_flags_patched);
 				dvar_set_variant_hook.create(0x1422C9030_g, dvar_set_variant_stub);
 
 				// Show all known dvars in console

--- a/src/client/component/dvars_patches.cpp
+++ b/src/client/component/dvars_patches.cpp
@@ -1,0 +1,82 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "game/game.hpp"
+#include "game/utils.hpp"
+#include "scheduler.hpp"
+
+#include <utils/hook.hpp>
+
+namespace dvars_patches
+{
+	namespace
+	{
+		void patch_dvars()
+		{
+			if (game::is_server())
+			{
+				game::register_dvar_bool("com_pauseSupported", false, game::DVAR_NONE, "Whether is pause is ever supported by the game mode");
+			}
+		}
+
+		void patch_flags()
+		{
+			game::dvar_set_flags("com_pauseSupported", game::DVAR_SERVERINFO);
+
+			if (game::is_client())
+			{
+				game::dvar_set_flags("r_dof_enable", game::DVAR_ARCHIVE);
+				game::dvar_set_flags("r_lodbiasrigid", game::DVAR_ARCHIVE);
+				game::dvar_set_flags("gpad_stick_deadzone_max", game::DVAR_ARCHIVE);
+				game::dvar_set_flags("gpad_stick_deadzone_min", game::DVAR_ARCHIVE);
+			}
+
+			scheduler::execute(scheduler::pipeline::dvars_flags_patched);
+		}
+
+		void dof_enabled_stub(utils::hook::assembler& a)
+		{
+			const auto update_ads_dof = a.newLabel();
+
+			a.pushad64();
+			a.push(rax);
+
+			a.mov(rax, qword_ptr(0x14AE95478_g));  // r_dof_enable
+			a.cmp(byte_ptr(rax, 0x28), 1);
+
+			a.pop(rax);
+			a.je(update_ads_dof);
+
+			a.popad64();
+			a.jmp(0x141116ECB_g);
+
+			a.bind(update_ads_dof);
+			a.lea(rdx, ptr(rbx, 0x131EB4));
+			a.mov(ecx, esi);
+			a.call_aligned(0x141107EC0_g); // CG_UpdateAdsDof
+
+			a.popad64();
+			a.jmp(0x141116F49_g);
+		}
+	}
+
+	class component final : public generic_component
+	{
+	public:
+		void post_unpack() override
+		{
+			patch_dvars();
+			scheduler::once(patch_flags, scheduler::pipeline::main, 10s);
+
+			if (game::is_server())
+			{
+				return;
+			}
+
+			// toggle ADS dof based on r_dof_enable
+			utils::hook::jump(0x141116EBB_g, utils::hook::assemble(dof_enabled_stub), true);
+		}
+	};
+}
+
+REGISTER_COMPONENT(dvars_patches::component)

--- a/src/client/component/loot.cpp
+++ b/src/client/component/loot.cpp
@@ -5,6 +5,7 @@
 
 #include "scheduler.hpp"
 #include "game/game.hpp"
+#include "game/utils.hpp"
 
 namespace loot
 {
@@ -95,14 +96,10 @@ namespace loot
 	{
 		void post_unpack() override
 		{
-			dvar_cg_unlockall_loot = game::Dvar_RegisterBool(game::Dvar_GenerateHash("cg_unlockall_loot"), "cg_unlockall_loot", false, (game::dvarFlags_e)0x0, "Unlocks blackmarket loot");
-			dvar_cg_unlockall_loot->debugName = "cg_unlockall_loot";
-			dvar_cg_unlockall_purchases = game::Dvar_RegisterBool(game::Dvar_GenerateHash("cg_unlockall_purchases"), "cg_unlockall_purchases", false, (game::dvarFlags_e)0x0, "Unlock all purchases with tokens");
-			dvar_cg_unlockall_purchases->debugName = "cg_unlockall_purchases";
-			dvar_cg_unlockall_attachments = game::Dvar_RegisterBool(game::Dvar_GenerateHash("cg_unlockall_attachments"), "cg_unlockall_attachments", false, (game::dvarFlags_e)0x0, "Unlocks all attachments");
-			dvar_cg_unlockall_attachments->debugName = "cg_unlockall_attachments";
-			dvar_cg_cg_unlockall_camos = game::Dvar_RegisterBool(game::Dvar_GenerateHash("cg_unlockall_camos"), "cg_unlockall_camos", false, (game::dvarFlags_e)0x0, "Unlocks all camos");
-			dvar_cg_cg_unlockall_camos->debugName = "cg_unlockall_camos";
+			dvar_cg_unlockall_loot = game::register_dvar_bool("cg_unlockall_loot", false, game::DVAR_ARCHIVE, "Unlocks blackmarket loot");
+			dvar_cg_unlockall_purchases = game::register_dvar_bool("cg_unlockall_purchases", false, game::DVAR_ARCHIVE, "Unlock all purchases with tokens");
+			dvar_cg_unlockall_attachments = game::register_dvar_bool("cg_unlockall_attachments", false, game::DVAR_ARCHIVE, "Unlocks all attachments");
+			dvar_cg_cg_unlockall_camos = game::register_dvar_bool("cg_unlockall_camos", false, game::DVAR_ARCHIVE, "Unlocks all camos");
 
 			loot_getitemquantity_hook.create(0x141E82C00_g, loot_getitemquantity_stub);
 			liveinventory_getitemquantity_hook.create(0x141E09030_g, liveinventory_getitemquantity_stub);

--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -1,7 +1,6 @@
 #include <std_include.hpp>
 #include "loader/component_loader.hpp"
 #include "game/game.hpp"
-#include "game/utils.hpp"
 
 #include "party.hpp"
 #include "network.hpp"
@@ -13,7 +12,6 @@
 #include <utils/info_string.hpp>
 #include <utils/cryptography.hpp>
 #include <utils/concurrency.hpp>
-
 
 namespace party
 {

--- a/src/client/component/scheduler.hpp
+++ b/src/client/component/scheduler.hpp
@@ -16,6 +16,9 @@ namespace scheduler
 		// The game's main thread
 		main,
 
+		// Dvars flags have been patched, ready to be set from config file
+		dvars_flags_patched,
+
 		// Dvars are done loading from the config file
 		dvars_loaded,
 

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -646,10 +646,11 @@ namespace game
 
 	enum dvarFlags_e
 	{
+		DVAR_NONE = 0,
 		DVAR_ARCHIVE = 1 << 0,
 		DVAR_USERINFO = 1 << 1,
-		DVAR_SYSTEMINFO = 1 << 2,
-		DVAR_CODINFO = 1 << 3,
+		DVAR_SERVERINFO = 1 << 2,
+		DVAR_SYSTEMINFO = 1 << 3,
 		DVAR_LATCH = 1 << 4,
 		DVAR_ROM = 1 << 5,
 		DVAR_SAVED = 1 << 6,

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -106,7 +106,7 @@ namespace game
 	WEAK symbol<bool(const dvar_t* dvar)> Dvar_GetBool{0x1422BCED0};
 	WEAK symbol<dvar_t*(dvarStrHash_t hash, const char* dvarName, bool value, dvarFlags_e flags,
 	                    const char* description)> Dvar_RegisterBool{
-		0x1422D0900
+		0x1422D0900, 0x14057B500
 	};
 	WEAK symbol<dvar_t*(dvarStrHash_t hash, const char* dvarName, const char* value, dvarFlags_e flags,
 	                    const char* description)> Dvar_RegisterString{
@@ -115,6 +115,9 @@ namespace game
 	WEAK symbol<void (void (*callback)(const dvar_t*, void*), void* userData)> Dvar_ForEach{0x1422BCD00};
 	WEAK symbol<void(const char* dvarName, const char* string, bool createIfMissing)> Dvar_SetFromStringByName{
 		0x1422C7500
+	};
+	WEAK symbol<dvar_t* (dvar_t* dvar, eModes mode)> Dvar_GetSessionModeSpecificDvar{
+		0x1422BF500, 0x140575D90
 	};
 
 	// UI

--- a/src/client/game/utils.cpp
+++ b/src/client/game/utils.cpp
@@ -26,4 +26,68 @@ namespace game
 
 		return dvar->current.value.integer;
 	}
+
+	bool get_dvar_bool(const char* dvar_name)
+	{
+		const auto dvar = Dvar_FindVar(dvar_name);
+		if (!dvar)
+		{
+			return {};
+		}
+
+		return dvar->current.value.enabled;
+	}
+
+	dvar_t* register_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description)
+	{
+		const auto hash = Dvar_GenerateHash(dvar_name);
+		auto registered_dvar = Dvar_RegisterBool(hash, dvar_name, value, flags, description);
+
+		if (registered_dvar)
+		{
+			registered_dvar->debugName = dvar_name;
+		}
+
+		return registered_dvar;
+	}
+
+	void dvar_add_flags(const char* dvar_name, const dvarFlags_e flags)
+	{
+		auto dvar = Dvar_FindVar(dvar_name);
+
+		if (!dvar)
+		{
+			return;
+		}
+
+		auto dvar_to_change = dvar;
+
+		if (dvar_to_change->type == DVAR_TYPE_SESSIONMODE_BASE_DVAR)
+		{
+			const auto mode = Com_SessionMode_GetMode();
+			dvar_to_change = Dvar_GetSessionModeSpecificDvar(dvar_to_change, mode);
+		}
+
+		dvar_to_change->flags |= flags;
+	}
+
+	void dvar_set_flags(const char* dvar_name, const dvarFlags_e flags)
+	{
+		auto dvar = Dvar_FindVar(dvar_name);
+
+		if (!dvar)
+		{
+			return;
+		}
+
+		auto dvar_to_change = dvar;
+
+		if (dvar_to_change->type == DVAR_TYPE_SESSIONMODE_BASE_DVAR)
+		{
+			const auto mode = Com_SessionMode_GetMode();
+			dvar_to_change = Dvar_GetSessionModeSpecificDvar(dvar_to_change, mode);
+		}
+
+		dvar_to_change->flags = flags;
+	}
 }

--- a/src/client/game/utils.hpp
+++ b/src/client/game/utils.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
+#include "structs.hpp"
+
 namespace game
 {
 	std::string get_dvar_string(const char* dvar_name);
 	int get_dvar_int(const char* dvar_name);
+	bool get_dvar_bool(const char* dvar_name);
+
+	dvar_t* register_dvar_bool(const char* dvar_name, bool value, dvarFlags_e flags, const char* description);
+	void dvar_add_flags(const char* dvar, dvarFlags_e flags);
+	void dvar_set_flags(const char* dvar_name, dvarFlags_e flags);
 }


### PR DESCRIPTION
- Fix archive dvars getting their debug names stripped
- Allows "r_dof_enable", "r_lodbiasrigid", "gpad_stick_deadzone_max", "gpad_stick_deadzone_min" to be changed through console.
- Removes ADS dof when "r_dof_enable" == 0.
- Some minor refactoring

I hope I did the assembly correct, first time doing so :p Let me know if it's not correct.

This PR should close #148 and #206 