### PR TITLE
Remove schedule delay dvar patches

### DIFF
--- a/src/client/component/dvars_patches.cpp
+++ b/src/client/component/dvars_patches.cpp
@@ -13,16 +13,11 @@ namespace dvars_patches
 	{
 		void patch_dvars()
 		{
-			if (game::is_server())
-			{
-				game::register_dvar_bool("com_pauseSupported", false, game::DVAR_NONE, "Whether is pause is ever supported by the game mode");
-			}
+			game::register_sessionmode_dvar_bool("com_pauseSupported", !game::is_server(), game::DVAR_SERVERINFO, "Whether is pause is ever supported by the game mode");
 		}
 
 		void patch_flags()
 		{
-			game::dvar_set_flags("com_pauseSupported", game::DVAR_SERVERINFO);
-
 			if (game::is_client())
 			{
 				game::dvar_set_flags("r_dof_enable", game::DVAR_ARCHIVE);
@@ -65,8 +60,8 @@ namespace dvars_patches
 	public:
 		void post_unpack() override
 		{
-			patch_dvars();
-			scheduler::once(patch_flags, scheduler::pipeline::main, 10s);
+			scheduler::once(patch_dvars, scheduler::pipeline::main);
+			scheduler::once(patch_flags, scheduler::pipeline::main);
 
 			if (game::is_server())
 			{

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -108,6 +108,10 @@ namespace game
 	                    const char* description)> Dvar_RegisterBool{
 		0x1422D0900, 0x14057B500
 	};
+	WEAK symbol<dvar_t* (dvarStrHash_t hash, const char* dvarName, bool value, dvarFlags_e flags,
+		const char* description)> Dvar_SessionModeRegisterBool{
+			0x1422D0D40, 0x14057BAA0
+	};
 	WEAK symbol<dvar_t*(dvarStrHash_t hash, const char* dvarName, const char* value, dvarFlags_e flags,
 	                    const char* description)> Dvar_RegisterString{
 		0x1422D0B70

--- a/src/client/game/utils.cpp
+++ b/src/client/game/utils.cpp
@@ -38,6 +38,19 @@ namespace game
 		return dvar->current.value.enabled;
 	}
 
+	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description)
+	{
+		const auto hash = Dvar_GenerateHash(dvar_name);
+		auto registered_dvar = Dvar_SessionModeRegisterBool(hash, dvar_name, value, flags, description);
+
+		if (registered_dvar)
+		{
+			registered_dvar->debugName = dvar_name;
+		}
+
+		return registered_dvar;
+	}
+
 	dvar_t* register_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description)
 	{
 		const auto hash = Dvar_GenerateHash(dvar_name);

--- a/src/client/game/utils.hpp
+++ b/src/client/game/utils.hpp
@@ -9,6 +9,7 @@ namespace game
 	bool get_dvar_bool(const char* dvar_name);
 
 	dvar_t* register_dvar_bool(const char* dvar_name, bool value, dvarFlags_e flags, const char* description);
+	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description);
 	void dvar_add_flags(const char* dvar, dvarFlags_e flags);
 	void dvar_set_flags(const char* dvar_name, dvarFlags_e flags);
 }


### PR DESCRIPTION
The dvar is now still replicated, but it defaults to true for some reason on servers. I'll check it out another time.
I hope this fixes the issue for @supitsmike