### PR TITLE
Fix registering sessionmode bool dvars

### DIFF
--- a/src/client/component/dvars_patches.cpp
+++ b/src/client/component/dvars_patches.cpp
@@ -66,12 +66,6 @@ namespace dvars_patches
 
 			// toggle ADS dof based on r_dof_enable
 			utils::hook::jump(0x141116EBB_g, utils::hook::assemble(dof_enabled_stub));
-
-			// De-Arxan Dvar_SessionModeSetDefaultBool
-			utils::hook::nop(0x1422D0EDB_g, 9);
-			utils::hook::jump(0x1422D0EE6_g, 0x1422D11BA_g);
-			utils::hook::jump(0x1422D11D1_g, 0x1422D11EC_g);
-			utils::hook::jump(0x1422D11F1_g, 0x1422D142C_g);
 		}
 	};
 }

--- a/src/client/component/dvars_patches.cpp
+++ b/src/client/component/dvars_patches.cpp
@@ -13,7 +13,7 @@ namespace dvars_patches
 	{
 		void patch_dvars()
 		{
-			game::register_sessionmode_dvar_bool("com_pauseSupported", !game::is_server(), game::DVAR_SERVERINFO, "Whether is pause is ever supported by the game mode");
+			game::register_sessionmode_dvar_bool("com_pauseSupported", !game::is_server(), game::DVAR_SERVERINFO, "Whether is pause is ever supported by the game mode", game::MODE_ZOMBIES);
 		}
 
 		void patch_flags()
@@ -66,6 +66,12 @@ namespace dvars_patches
 
 			// toggle ADS dof based on r_dof_enable
 			utils::hook::jump(0x141116EBB_g, utils::hook::assemble(dof_enabled_stub));
+
+			// De-Arxan Dvar_SessionModeSetDefaultBool
+			utils::hook::nop(0x1422D0EDB_g, 9);
+			utils::hook::jump(0x1422D0EE6_g, 0x1422D11BA_g);
+			utils::hook::jump(0x1422D11D1_g, 0x1422D11EC_g);
+			utils::hook::jump(0x1422D11F1_g, 0x1422D142C_g);
 		}
 	};
 }

--- a/src/client/component/dvars_patches.cpp
+++ b/src/client/component/dvars_patches.cpp
@@ -13,7 +13,7 @@ namespace dvars_patches
 	{
 		void patch_dvars()
 		{
-			game::register_sessionmode_dvar_bool("com_pauseSupported", !game::is_server(), game::DVAR_SERVERINFO, "Whether is pause is ever supported by the game mode", game::MODE_ZOMBIES);
+			game::register_sessionmode_dvar_bool("com_pauseSupported", !game::is_server(), game::DVAR_SERVERINFO, "Whether is pause is ever supported by the game mode");
 		}
 
 		void patch_flags()

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -108,19 +108,22 @@ namespace game
 	                    const char* description)> Dvar_RegisterBool{
 		0x1422D0900, 0x14057B500
 	};
-	WEAK symbol<dvar_t* (dvarStrHash_t hash, const char* dvarName, bool value, dvarFlags_e flags,
+	WEAK symbol<dvar_t*(dvarStrHash_t hash, const char* dvarName, bool value, dvarFlags_e flags,
 		const char* description)> Dvar_SessionModeRegisterBool{
 			0x1422D0D40, 0x14057BAA0
+	};
+	WEAK symbol<void(dvarStrHash_t hash, bool value, eModes mode)> Dvar_SessionModeSetDefaultBool{
+		0x1422D0E90, 0x14057BCE0
 	};
 	WEAK symbol<dvar_t*(dvarStrHash_t hash, const char* dvarName, const char* value, dvarFlags_e flags,
 	                    const char* description)> Dvar_RegisterString{
 		0x1422D0B70
 	};
-	WEAK symbol<void (void (*callback)(const dvar_t*, void*), void* userData)> Dvar_ForEach{0x1422BCD00};
+	WEAK symbol<void(void (*callback)(const dvar_t*, void*), void* userData)> Dvar_ForEach{0x1422BCD00};
 	WEAK symbol<void(const char* dvarName, const char* string, bool createIfMissing)> Dvar_SetFromStringByName{
 		0x1422C7500
 	};
-	WEAK symbol<dvar_t* (dvar_t* dvar, eModes mode)> Dvar_GetSessionModeSpecificDvar{
+	WEAK symbol<dvar_t*(dvar_t* dvar, eModes mode)> Dvar_GetSessionModeSpecificDvar{
 		0x1422BF500, 0x140575D90
 	};
 

--- a/src/client/game/utils.cpp
+++ b/src/client/game/utils.cpp
@@ -38,7 +38,7 @@ namespace game
 		return dvar->current.value.enabled;
 	}
 
-	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description)
+	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description, const eModes mode)
 	{
 		const auto hash = Dvar_GenerateHash(dvar_name);
 		auto registered_dvar = Dvar_SessionModeRegisterBool(hash, dvar_name, value, flags, description);
@@ -46,6 +46,7 @@ namespace game
 		if (registered_dvar)
 		{
 			registered_dvar->debugName = dvar_name;
+			game::Dvar_SessionModeSetDefaultBool(hash, value, mode);
 		}
 
 		return registered_dvar;

--- a/src/client/game/utils.cpp
+++ b/src/client/game/utils.cpp
@@ -46,7 +46,18 @@ namespace game
 		if (registered_dvar)
 		{
 			registered_dvar->debugName = dvar_name;
-			game::Dvar_SessionModeSetDefaultBool(hash, value, mode);
+
+			if (mode == MODE_COUNT)
+			{
+				for (int i = MODE_FIRST; i < MODE_COUNT; ++i)
+				{
+					game::Dvar_SessionModeSetDefaultBool(hash, value, static_cast<eModes>(i));
+				}
+			}
+			else
+			{
+				game::Dvar_SessionModeSetDefaultBool(hash, value, mode);
+			}
 		}
 
 		return registered_dvar;

--- a/src/client/game/utils.cpp
+++ b/src/client/game/utils.cpp
@@ -51,12 +51,12 @@ namespace game
 			{
 				for (int i = MODE_FIRST; i < MODE_COUNT; ++i)
 				{
-					game::Dvar_SessionModeSetDefaultBool(hash, value, static_cast<eModes>(i));
+					game::Dvar_SessionModeSetDefaultBool.call_safe(hash, value, static_cast<eModes>(i));
 				}
 			}
 			else
 			{
-				game::Dvar_SessionModeSetDefaultBool(hash, value, mode);
+				game::Dvar_SessionModeSetDefaultBool.call_safe(hash, value, mode);
 			}
 		}
 

--- a/src/client/game/utils.hpp
+++ b/src/client/game/utils.hpp
@@ -9,7 +9,7 @@ namespace game
 	bool get_dvar_bool(const char* dvar_name);
 
 	dvar_t* register_dvar_bool(const char* dvar_name, bool value, dvarFlags_e flags, const char* description);
-	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description);
+	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description, const eModes mode);
 	void dvar_add_flags(const char* dvar, dvarFlags_e flags);
 	void dvar_set_flags(const char* dvar_name, dvarFlags_e flags);
 }

--- a/src/client/game/utils.hpp
+++ b/src/client/game/utils.hpp
@@ -9,7 +9,7 @@ namespace game
 	bool get_dvar_bool(const char* dvar_name);
 
 	dvar_t* register_dvar_bool(const char* dvar_name, bool value, dvarFlags_e flags, const char* description);
-	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description, const eModes mode);
+	dvar_t* register_sessionmode_dvar_bool(const char* dvar_name, const bool value, const dvarFlags_e flags, const char* description, const eModes mode = MODE_COUNT);
 	void dvar_add_flags(const char* dvar, dvarFlags_e flags);
 	void dvar_set_flags(const char* dvar_name, dvarFlags_e flags);
 }


### PR DESCRIPTION
This fixes the issue that the bool value does not get updated when registering sessionmode bool dvars.
I had to do some patches in the function `Dvar_SessionModeSetDefaultBool` on client side due arxan anti tampering. Calling this function would result in a freeze without these patches. I hope this won't cause any weird side effects. Atleast I did not notice them anymore once I properly patched it.