### PR TITLE
fix: make sure rcon is handled at the right time

### DIFF
--- a/src/client/component/rcon.cpp
+++ b/src/client/component/rcon.cpp
@@ -55,11 +55,10 @@ namespace rcon
 		void rcon_handler(const game::netadr_t& target, const network::data_view& data)
 		{
 			auto str_data = std::string(reinterpret_cast<const char*>(data.data()), data.size());
-			/*scheduler::once([target, s = std::move(str_data)]
+			scheduler::once([target, s = std::move(str_data)]
 			{
 				rcon_executer(target, s);
-			}, scheduler::main);*/
-			rcon_executer(target, str_data);
+			}, scheduler::main);
 		}
 	}
 


### PR DESCRIPTION
After some careful investigation, I came to the discovery of two crash dumps from the iw4x-client.
Both of these crash dumps are from RaidMax (IW4M) creator and they showcase one crash in a function called by Cmd_ExecuteSingleCommand which is used by RCon handler.
This leads me to believe that the function is in fact not thread safe and there is a "race condition" where the sv_cmd_buffer is read/written as an RCon request is being handled which can lead to this crash.
Using the scheduler should avoid the issue and be the safest course of action.
sorry if earlier I pressured you to have this removed.
iw4x-client will need a similar fix to fix the crash I discovered recently.