### PR TITLE
Use correct bdPublicProfileInfo version

### DIFF
--- a/src/client/game/demonware/services/bdProfiles.cpp
+++ b/src/client/game/demonware/services/bdProfiles.cpp
@@ -24,7 +24,7 @@ namespace demonware
 
 		auto* result = new bdPublicProfileInfo;
 		result->m_entityID = entity_id;
-		result->m_VERSION = 4;
+		result->m_VERSION = 3;
 
 		if (utils::io::read_file(std::format("players/user/profileInfo_{}", entity_id), &result->m_ddl))
 		{


### PR DESCRIPTION
Fixes the issue that emblem + calling card get reset after rebooting the game.