### PR TITLE
Workaround out-of-gobblegums

### DIFF
--- a/src/client/component/script.cpp
+++ b/src/client/component/script.cpp
@@ -13,6 +13,8 @@ namespace script
 	namespace
 	{
 		utils::hook::detour db_findxassetheader_hook;
+		utils::hook::detour gscr_get_bgb_remaining_hook;
+
 		std::unordered_map<std::string, game::RawFile*> loaded_scripts;
 
 		game::RawFile* get_loaded_script(const std::string& name)
@@ -110,6 +112,11 @@ namespace script
 
 			return asset_header;
 		}
+
+		void gscr_get_bgb_remaining_stub(game::scriptInstance_t inst, void* entref)
+		{
+			game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 255);
+		}
 	}
 
 	struct component final : generic_component
@@ -126,6 +133,7 @@ namespace script
 			}
 
 			db_findxassetheader_hook.create(game::select(0x141420ED0, 0x1401D5FB0), db_findxassetheader_stub);
+			gscr_get_bgb_remaining_hook.create(game::select(0x141A8CAB0, 0x1402D2310), gscr_get_bgb_remaining_stub);
 		}
 	};
 };

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -139,7 +139,7 @@ namespace game
 	WEAK symbol<void(int localClientNum)> CL_CheckKeepDrawingConnectScreen{0x1413CCAE0};
 
 	// Scr
-	WEAK symbol<void(scriptInstance_t inst, int value)> Scr_AddInt{0x0, 0x14016F160};
+	WEAK symbol<void(scriptInstance_t inst, int value)> Scr_AddInt{0x1412E9870, 0x14016F160};
 	WEAK symbol<void(scriptInstance_t inst, const char* value)> Scr_AddString{0x0, 0x14016F320};
 	WEAK symbol<const char*(scriptInstance_t inst, unsigned int index)> Scr_GetString{0x0, 0x140171490};
 	WEAK symbol<void(gentity_s* ent, ScrVarCanonicalName_t stringValue, unsigned int paramcount)> Scr_Notify_Canon{


### PR DESCRIPTION
Bit of a crappy work around but atleast it solves out of gobblegums issue for now.
Since the gsc function depends on the lobby system it has no info on the other clients.
Therefore always returning zero for the non-hosts.
![image](https://user-images.githubusercontent.com/70229620/230501360-f01bc909-253c-4d85-b61c-a3489e438b85.png)

Not sure if it's a desired workaround. Feel free to close if not.
