### PR TITLE
fix: support for hardcore on the server browser

### DIFF
--- a/src/client/component/getinfo.cpp
+++ b/src/client/component/getinfo.cpp
@@ -113,7 +113,7 @@ namespace getinfo
 				info.set("gamemode", utils::string::va("%i", Com_SessionMode_GetGameMode()));
 				info.set("sv_running", utils::string::va("%i", game::is_server_running()));
 				info.set("dedicated", utils::string::va("%i", game::is_server() ? 1 : 0));
-				info.set("hc", utils::string::va("%i", game::Com_GametypeSettings_GetUInt("hardcoremode", false)));
+				info.set("hc", utils::string::va("%u", game::Com_GametypeSettings_GetUInt("hardcoremode", false)));
 				info.set("shortversion", SHORTVERSION);
 
 				network::send(target, "infoResponse", info.build(), '\n');

--- a/src/client/component/getinfo.cpp
+++ b/src/client/component/getinfo.cpp
@@ -113,6 +113,7 @@ namespace getinfo
 				info.set("gamemode", utils::string::va("%i", Com_SessionMode_GetGameMode()));
 				info.set("sv_running", utils::string::va("%i", game::is_server_running()));
 				info.set("dedicated", utils::string::va("%i", game::is_server() ? 1 : 0));
+				info.set("hc", utils::string::va("%i", game::Com_GametypeSettings_GetUInt("hardcoremode", false)));
 				info.set("shortversion", SHORTVERSION);
 
 				network::send(target, "infoResponse", info.build(), '\n');

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -31,6 +31,7 @@ namespace game
 	WEAK symbol<void(const char* gametype, bool loadDefaultSettings)> Com_GametypeSettings_SetGametype{
 		0x1420F5980
 	};
+	WEAK symbol<unsigned int(const char* settingName, bool getDefault)> Com_GametypeSettings_GetUInt{0x1420F4E00, 0x1404FE5C0};
 	WEAK symbol<bool()> Com_IsRunningUILevel{0x142148350};
 	WEAK symbol<void(int localClientNum, eModes fromMode, eModes toMode, uint32_t flags)> Com_SwitchMode{
 		0x14214A4D0

--- a/src/client/steam/interfaces/matchmaking_servers.cpp
+++ b/src/client/steam/interfaces/matchmaking_servers.cpp
@@ -55,9 +55,10 @@ namespace steam
 			const auto mode = game::eModes(std::atoi(playmode.data()));
 
 			const auto* tags = ::utils::string::va(
-				R"(\gametype\%s\dedicated\%s\ranked\false\hardcore\false\zombies\%s\modName\\playerCount\%d\bots\%d\)",
+				R"(\gametype\%s\dedicated\%s\ranked\false\hardcore\%s\zombies\%s\modName\\playerCount\%d\bots\%d\)",
 				info.get("gametype").data(),
 				info.get("dedicated") == "1" ? "true" : "false",
+				info.get("hc") == "1" ? "true" : "false",
 				mode == game::MODE_ZOMBIES ? "true" : "false",
 				server.m_nPlayers, atoi(info.get("bots").data()));
 


### PR DESCRIPTION
Added support for the hardcore skull icon in the server browser
![image](https://user-images.githubusercontent.com/23278562/231011215-10294593-2988-417b-969e-c3ad355ece07.png)
