### PR TITLE
Fix workaround for bad client reliableAcknowledge DOS

### DIFF
--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -17,7 +17,7 @@ namespace patches
 
 		void sv_execute_client_messages_stub(game::client_s* client, game::msg_t* msg)
 		{
-			if (client->reliableAcknowledge < 0)
+			if ((client->reliableSequence - client->reliableAcknowledge) < 0)
 			{
 				client->reliableAcknowledge = client->reliableSequence;
 				network::send(client->address, "error", "EXE_LOSTRELIABLECOMMANDS");


### PR DESCRIPTION
We should be checking the difference > 0; not just the reliableAcknowledge.