### PR TITLE
Fix: Check if button exists first in custom mod UI

### DIFF
--- a/data/ui_scripts/frontend_menus/__init__.lua
+++ b/data/ui_scripts/frontend_menus/__init__.lua
@@ -87,7 +87,10 @@ end
 local addCustomButtons = function(controller, menuId, buttonTable, isLeader)
   if menuId == LobbyData.UITargets.UI_MPLOBBYMAIN.id then
     utils.RemoveSpaces(buttonTable)
-    utils.AddSpacer(buttonTable, utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.THEATER_MP) - 1)
+    local theaterIndex = utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.THEATER_MP)
+    if theaterIndex ~= nil then
+      utils.AddSpacer(buttonTable, theaterIndex - 1)
+    end
   end
 
   if menuId == LobbyData.UITargets.UI_MPLOBBYONLINE.id or menuId == LobbyData.UITargets.UI_ZMLOBBYONLINE.id then
@@ -121,11 +124,14 @@ local addCustomButtons = function(controller, menuId, buttonTable, isLeader)
 
   if menuId == LobbyData.UITargets.UI_ZMLOBBYONLINE.id then
     utils.RemoveButton(buttonTable, CoD.LobbyButtons.THEATER_ZM)
-    utils.AddLargeButton(controller, buttonTable, CoD.LobbyButtons.THEATER_ZM, #buttonTable + 1)
+    utils.AddLargeButton(controller, buttonTable, CoD.LobbyButtons.THEATER_ZM)
 
     utils.RemoveSpaces(buttonTable)
     utils.AddSpacer(buttonTable, utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.SERVER_BROWSER))
-    utils.AddSpacer(buttonTable, utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.ZM_BUBBLEGUM_BUFFS) - 1)
+    local bgbIndex = utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.ZM_BUBBLEGUM_BUFFS)
+    if bgbIndex ~= nil then
+      utils.AddSpacer(buttonTable, bgbIndex - 1)
+    end
     utils.AddSpacer(buttonTable, utils.GetButtonIndex(buttonTable, CoD.LobbyButtons.STATS))
   end
 end

--- a/data/ui_scripts/frontend_menus/utils.lua
+++ b/data/ui_scripts/frontend_menus/utils.lua
@@ -17,6 +17,9 @@ local SetButtonState = function(button, state)
 end
 
 local RemoveButton = function(buttonTable, button)
+  if not button then
+    return
+  end
   for id, v in pairs(buttonTable) do
     if buttonTable[id].optionDisplay == button.stringRef then
       table.remove(buttonTable, id)
@@ -31,6 +34,9 @@ local RemoveSpaces = function(buttonTable)
 end
 
 local GetButtonIndex = function(buttonTable, button)
+  if not button then
+    return nil
+  end
   for id, v in pairs(buttonTable) do
     if buttonTable[id].optionDisplay == button.stringRef then
       return id


### PR DESCRIPTION
Mods that change the ui can potentially remove menu buttons that boiii expects to be there. This accommodates for missing buttons.

Closes https://github.com/momo5502/boiii/issues/581