### PR TITLE
small fixes

### DIFF
--- a/src/client/component/workshop.cpp
+++ b/src/client/component/workshop.cpp
@@ -82,7 +82,7 @@ namespace workshop
 			utils::string::copy(item.description, doc["Description"].GetString());
 			utils::string::copy(item.folderName, doc["FolderName"].GetString());
 			utils::string::copy(item.publisherId, doc["PublisherID"].GetString());
-			item.publisherIdInteger = std::stoul(item.publisherId);
+			item.publisherIdInteger = std::strtoul(item.publisherId, nullptr, 10);
 		}
 
 		void load_usermap_content_stub(void* usermaps_count, int type)
@@ -94,7 +94,7 @@ namespace workshop
 				auto& usermap_data = game::usermapsPool[i];
 
 				// foldername == title -> non-steam workshop usercontent
-				if (std::strcmp(usermap_data.folderName, usermap_data.title))
+				if (std::strcmp(usermap_data.folderName, usermap_data.title) != 0)
 				{
 					continue;
 				}
@@ -111,7 +111,7 @@ namespace workshop
 			{
 				auto& mod_data = game::modsPool[i];
 
-				if (std::strcmp(mod_data.folderName, mod_data.title))
+				if (std::strcmp(mod_data.folderName, mod_data.title) != 0)
 				{
 					continue;
 				}

--- a/src/common/utils/string.cpp
+++ b/src/common/utils/string.cpp
@@ -68,11 +68,13 @@ namespace utils::string
 
 	bool is_numeric(const std::string& text)
 	{
-		if (text.size() <= 0 || !std::isdigit(text[0])) return false;
-		return std::ranges::all_of(text.begin(), text.end(), [](const char input)
+		auto it = text.begin();
+		while (it != text.end() && std::isdigit(static_cast<unsigned char>(*it)))
 		{
-			return std::isdigit(input) != 0;
-		});
+			++it;
+		}
+
+		return !text.empty() && it == text.end();
 	}
 
 	std::string dump_hex(const std::string& data, const std::string& separator)
@@ -154,9 +156,9 @@ namespace utils::string
 			if (*in != '$' && *in != '{' && *in != '}')
 			{
 				*out++ = *in;
-				i++;
+				++i;
 			}
-			in++;
+			++in;
 		}
 
 		*out = '\0';


### PR DESCRIPTION
Readability of std::strcmp is important in my opinion, that is why extensions like re-sharper & clang-tidy recommend to always explicitly comparing the result.

Other than that is_numeric needs the other fixes I already did quite some time ago to string.cpp where the character should be converted to unsigned char to avoid UB. Additionally, the readability of the function was improved.

FInally fixed a would be crash caused by stoul being a throwable function.