### PR TITLE
Make usercontent zone folder toggleable

### DIFF
--- a/src/client/component/workshop.cpp
+++ b/src/client/component/workshop.cpp
@@ -4,6 +4,7 @@
 
 #include "game/game.hpp"
 #include "game/utils.hpp"
+#include "command.hpp"
 
 #include <utils/hook.hpp>
 #include <utils/string.hpp>
@@ -316,6 +317,11 @@ namespace workshop
 	public:
 		void post_unpack() override
 		{
+			command::add("userContentReload", [](const command::params& params)
+			{
+				game::reloadUserContent();
+			});
+
 			enable_zone_folder = game::register_dvar_bool("enable_zone_folder", false, game::DVAR_ARCHIVE, "Load custom zones from the zone folder within the usermaps/mods folder");
 
 			utils::hook::jump(game::select(0x1420D6A99, 0x1404E2929), utils::hook::assemble(override_path_mods_stub));

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -107,6 +107,7 @@ namespace game
 
 	WEAK symbol<bool()> isModLoaded{0x1420D5020};
 	WEAK symbol<void(int localClientNum, const char* mod, bool)> loadMod{0x1420D6930};
+	WEAK symbol<void()> reloadUserContent{0x1420D66C0, 0x1404E25C0};
 
 	// Dvar
 	WEAK symbol<bool(const dvar_t* dvar)> Dvar_IsSessionModeBaseDvar{0x1422C23A0, 0x140576890};


### PR DESCRIPTION
It seems mod developers prefer to keep the zone folder which I can understand. So I came up with this idea. 
`enable_zone_folder 1` loads the mods/usermaps fastfiles from the zone folder just like how it was before.

I also added a command `userContentReload` that reloads the usermaps/mods in their pools.

Is there a way to reduce the redundancy of the asm stubs? Because they are very similiar only the strings + addresses differ.
I feel like this might not be very clean but I don't see a way to do this differently. So let me know if it needs some changes :)