### PR TITLE
maint(auth): only write keys if there is anything to write

### DIFF
--- a/src/client/component/auth.cpp
+++ b/src/client/component/auth.cpp
@@ -330,10 +330,16 @@ namespace auth
 	{
 		game::Info_SetValueForKey(s, key, value);
 
-		const auto password_text = (password && password->current.value.string) ? password->current.value.string : "";
-		game::Info_SetValueForKey(s, "password", password_text);
+		if (password && *password->current.value.string)
+		{
+			game::Info_SetValueForKey(s, "password", password->current.value.string);
+		}
 
-		game::Info_SetValueForKey(s, "clanAbbrev", game::LiveStats_GetClanTagText(0));
+		const auto* clan_abbrev = game::LiveStats_GetClanTagText(0);
+		if (*clan_abbrev)
+		{
+			game::Info_SetValueForKey(s, "clanAbbrev", clan_abbrev);
+		}
 	}
 
 	struct component final : generic_component


### PR DESCRIPTION
Because on the server-side code if a key is not present in the info string the function that parses it returns an empty string by default,  there should not be a strong need to write an empty string ourselves on the client side.
I wanted to do this the first time, so this basically means we are avoiding making the info string unnecessary longer before the client transmits it.