### PR TITLE
No longer use fs_game to send mod info

### DIFF
--- a/src/client/component/getinfo.cpp
+++ b/src/client/component/getinfo.cpp
@@ -116,8 +116,8 @@ namespace getinfo
 				info.set("sv_running", std::to_string(game::is_server_running()));
 				info.set("dedicated", game::is_server() ? "1" : "0");
 				info.set("hc", std::to_string(game::Com_GametypeSettings_GetUInt("hardcoremode", false)));
-				info.set("modName", workshop::get_mod_resized_name(game::get_dvar_string("fs_game")));
-				info.set("modId", workshop::get_mod_publisher_id(game::get_dvar_string("fs_game")));
+				info.set("modName", workshop::get_mod_resized_name());
+				info.set("modId", workshop::get_mod_publisher_id());
 				info.set("shortversion", SHORTVERSION);
 
 				network::send(target, "infoResponse", info.build(), '\n');

--- a/src/client/component/workshop.cpp
+++ b/src/client/component/workshop.cpp
@@ -170,32 +170,34 @@ namespace workshop
 		}
 	}
 
-	std::string get_mod_resized_name(const std::string& dir_name)
+	std::string get_mod_resized_name()
 	{
-		if (dir_name == "usermaps" || dir_name.empty())
+		const std::string loaded_mod_id = game::getPublisherIdFromLoadedMod();
+
+		if (loaded_mod_id == "usermaps" || loaded_mod_id.empty())
 		{
-			return dir_name;
+			return loaded_mod_id;
 		}
 
-		std::string result = dir_name;
+		std::string mod_name = loaded_mod_id;
 
 		for (unsigned int i = 0; i < *game::modsCount; ++i)
 		{
 			const auto& mod_data = game::modsPool[i];
 
-			if (utils::string::ends_with(mod_data.contentPathToZoneFiles, dir_name))
+			if (mod_data.publisherId == loaded_mod_id)
 			{
-				result = mod_data.title;
+				mod_name = mod_data.title;
 				break;
 			}
 		}
 
-		if (result.size() > 31)
+		if (mod_name.size() > 31)
 		{
-			result.resize(31);
+			mod_name.resize(31);
 		}
 
-		return result;
+		return mod_name;
 	}
 
 	std::string get_usermap_publisher_id(const std::string& zone_name)
@@ -218,29 +220,22 @@ namespace workshop
 		return {};
 	}
 
-	std::string get_mod_publisher_id(const std::string& dir_name)
+	std::string get_mod_publisher_id()
 	{
-		if (dir_name == "usermaps" || dir_name.empty())
+		const std::string loaded_mod_id = game::getPublisherIdFromLoadedMod();
+
+		if (loaded_mod_id == "usermaps" || loaded_mod_id.empty())
 		{
-			return dir_name;
+			return loaded_mod_id;
 		}
 
-		for (unsigned int i = 0; i < *game::modsCount; ++i)
+		if (!utils::string::is_numeric(loaded_mod_id))
 		{
-			const auto& mod_data = game::modsPool[i];
-			if (utils::string::ends_with(mod_data.contentPathToZoneFiles, dir_name))
-			{
-				if (!utils::string::is_numeric(mod_data.publisherId))
-				{
-					printf("[ Workshop ] WARNING: The publisherId is not numerical you might have set your mod folder incorrectly!\n%s\n",
-						mod_data.absolutePathZoneFiles);
-				}
-
-				return mod_data.publisherId;
-			}
+			printf("[ Workshop ] WARNING: The publisherId: %s, is not numerical you might have set your mod folder incorrectly!\n",
+				loaded_mod_id.data());
 		}
 
-		return {};
+		return loaded_mod_id;
 	}
 
 	bool check_valid_usermap_id(const std::string& mapname, const std::string& pub_id)
@@ -274,6 +269,11 @@ namespace workshop
 
 	void setup_same_mod_as_host(const std::string& usermap, const std::string& mod)
 	{
+		if (game::getPublisherIdFromLoadedMod() == mod)
+		{
+			return;
+		}
+
 		if (!usermap.empty() || mod != "usermaps")
 		{
 			game::loadMod(0, mod.data(), true);

--- a/src/client/component/workshop.hpp
+++ b/src/client/component/workshop.hpp
@@ -3,8 +3,8 @@
 namespace workshop
 {
 	std::string get_usermap_publisher_id(const std::string& folder_name);
-	std::string get_mod_publisher_id(const std::string& folder_name);
-	std::string get_mod_resized_name(const std::string& folder_name);
+	std::string get_mod_publisher_id();
+	std::string get_mod_resized_name();
 	bool check_valid_usermap_id(const std::string& mapname, const std::string& pub_id);
 	bool check_valid_mod_id(const std::string& pub_id);
 	void setup_same_mod_as_host(const std::string& usermap, const std::string& mod);

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -110,6 +110,7 @@ namespace game
 	WEAK symbol<const char*(const char* name)> CopyString{0x1422AC220, 0x14056BD70};
 
 	WEAK symbol<bool()> isModLoaded{0x1420D5020};
+	WEAK symbol<const char*()> getPublisherIdFromLoadedMod{0x1420D7680, 0x1404E3230};
 	WEAK symbol<void(int localClientNum, const char* mod, bool)> loadMod{0x1420D6930};
 	WEAK symbol<void()> reloadUserContent{0x1420D66C0, 0x1404E25C0};
 


### PR DESCRIPTION
Some mods seems to alter the dvar `fs_game` while the host's in game. So direct connecting to clients no longer worked correctly with these mods. Since it caused the client to load the wrong mod.

This PR fixes that issue.