### PR TITLE
fix: add error message when no BO3 executable is found

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -292,6 +292,11 @@ namespace
 
 				const auto is_server = utils::flags::has_flag("dedicated") || (!has_client && has_server);
 
+				if (!has_client && !has_server)
+				{
+					throw std::runtime_error("Can't find a valid BlackOps3.exe or BlackOps3_UnrankedDedicatedServer.exe. Make sure you put boiii.exe in your Black Ops 3 installation folder.");
+				}
+
 				if (!is_server)
 				{
 					trigger_high_performance_gpu_switch();


### PR DESCRIPTION
Gives it a proper error message instead of "Failed to map BlackOps3.exe"

![image](https://user-images.githubusercontent.com/23278562/235777138-760bbaf4-fc98-4453-974a-111da706f714.png)
