### PR TITLE
Stats menu: unlock Easter eggs + set master rank

### DIFF
--- a/data/ui_scripts/stats/__init__.lua
+++ b/data/ui_scripts/stats/__init__.lua
@@ -16,6 +16,20 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 		if dvarName == "cg_unlockall_loot" then
 			Engine.SetDvar("ui_enableAllHeroes", f1_arg1.value)
 		end
+		if dvarName == "all_ee_completed" then
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_zod_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_zod_super_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_factory_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_factory_super_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_castle_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_castle_super_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_island_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_island_super_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_stalingrad_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_stalingrad_super_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname darkops_genesis_ee " .. f1_arg1.value)
+			Engine.ExecNow(f1_arg0, "statsetbyname DARKOPS_GENESIS_SUPER_EE " .. f1_arg1.value)
+		end
 	end
 
 	table.insert(optionsTable,
@@ -103,20 +117,38 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 					value = 1
 				},
 			}, nil, updateDvar))
-	table.insert(optionsTable,
-		CoD.OptionsUtility.CreateDvarSettings(controller, "Unlock all Specialists Outfits",
-			"All specialists outfits are unlocked.", "MPStatsSettings_unlockall_specialists_outfits",
-			"cg_unlockall_specialists_outfits", {
-				{
-					option = "MENU_DISABLED",
-					value = 0,
-					default = true
-				},
-				{
-					option = "MENU_ENABLED",
-					value = 1
-				},
-			}, nil, updateDvar))
+	if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+		table.insert(optionsTable,
+			CoD.OptionsUtility.CreateDvarSettings(controller, "Unlock all Specialists Outfits",
+				"All specialists outfits are unlocked.", "MPStatsSettings_unlockall_specialists_outfits",
+				"cg_unlockall_specialists_outfits", {
+					{
+						option = "MENU_DISABLED",
+						value = 0,
+						default = true
+					},
+					{
+						option = "MENU_ENABLED",
+						value = 1
+					},
+				}, nil, updateDvar))
+	end			
+	if Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+		table.insert(optionsTable,
+			CoD.OptionsUtility.CreateDvarSettings(controller, "Unlock Easter Eggs",
+				"Complete all Easter Egg Achievements.", "MPStatsSettings_complete_ee",
+				"all_ee_completed", {
+					{
+						option = "MENU_DISABLED",
+						value = 0,
+						default = true
+					},
+					{
+						option = "MENU_ENABLED",
+						value = 1
+					},
+				}, nil, updateDvar))
+	end
 
 	local rankLevels = {}
 	if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then

--- a/data/ui_scripts/stats/__init__.lua
+++ b/data/ui_scripts/stats/__init__.lua
@@ -151,43 +151,57 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 	end
 
 	local rankLevels = {}
-	if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
-		rankLevels = { 1, 10, 20, 30, 40, 50, 55 }
-	elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
-		rankLevels = { 1, 10, 20, 30, 35 }
-	end
 	local rankObjs = {}
-	local hasDefault = false
+	local hasDefault = true
+	local currentPrestige = CoD.PrestigeUtility.GetCurrentPLevel(controller, Engine.CurrentSessionMode())
 	local currentRank = CoD.BlackMarketUtility.GetCurrentRank(controller) + 1
-	for index, value in ipairs(rankLevels) do
-		table.insert(rankObjs, {
-			name = value,
-			value = value - 1,
-			default = value == currentRank,
-			title = "Rank Level",
-			desc = ""
-		})
-		if not hasDefault then
-			hasDefault = value == currentRank
+	
+	local isMasterPrestige = currentPrestige == 11
+
+	if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+		if not isMasterPrestige then
+			rankLevels = { 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55 }
+		else
+			rankLevels = { 56, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 }
+		end
+			
+	elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+		if not isMasterPrestige then
+			rankLevels = { 1, 5, 10, 15, 20, 25, 30, 35 }
+		else
+			rankLevels = { 36, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 }
 		end
 	end
 
-	if not hasDefault then
+	local maxlevel = math.max(table.unpack(rankLevels))
+	local minlevel = math.min(table.unpack(rankLevels))
+
+	for index, value in ipairs(rankLevels) do
 		table.insert(rankObjs, {
-			name = currentRank,
+			name = value <= minlevel and "Min" or value >= maxlevel and "Max" or value,
+			value = value - 1,
+			default = value == currentRank,
+			title = "Rank Level",
+			desc = value~=currentRank and "" or "Current Rank"
+		})
+	end
+
+	if hasDefault and currentRank ~= minlevel and currentRank < maxlevel and not isMasterPrestige then
+		table.insert(rankObjs, {
+			name = "Current: " .. tostring(currentRank <= minlevel and "Min" or currentRank >= maxlevel and "Max" or currentRank),
 			value = currentRank - 1,
 			default = true,
 			title = "Rank Level",
-			desc = ""
+			desc = "Do not adjust rank"
 		})
 	end
 
 	local prestigeTable = {}
-	for i = 0, 10 do
+	for i = 0, 11 do
 		table.insert(prestigeTable, {
-			name = i == 0 and "None" or i,
+			name = i == 0 and "None" or i==11 and "Master" or i,
 			value = i,
-			default = i == CoD.PrestigeUtility.GetCurrentPLevel(controller),
+			default = i == currentPrestige,
 			title = "Prestige",
 			desc = ""
 		})
@@ -228,25 +242,18 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 
 	table.insert(optionsTable, {
 		models = {
-			name = "Rank Level",
+			name = "Prestige",
 			desc = "",
 			image = nil,
-			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_level", rankObjs,
-				CoD.BlackMarketUtility.GetCurrentRank(controller), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
+			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_prestige", prestigeTable,
+				CoD.PrestigeUtility.GetCurrentPLevel(controller, Engine.CurrentSessionMode()), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
 					UpdateInfoModels(f1_arg1)
-					local rankTable = nil
-					if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
-						rankTable = "gamedata/tables/mp/mp_ranktable.csv"
-					elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
-						rankTable = "gamedata/tables/zm/zm_ranktable.csv"
+					local newPrestige = f1_arg1.value
+					if newPrestige == 11 then 
+						Engine.Exec( f1_arg0, "PrestigeStatsMaster " .. tostring( Engine.CurrentSessionMode() ) )
 					end
-					local skipLines = Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER and 3 or 2
-					local maxXp = tonumber(Engine.TableLookupGetColumnValueForRow(rankTable, f1_arg1.value + skipLines, 7))
-					if maxXp == nil then
-						maxXp = 9999999999
-					end
-					Engine.ExecNow(f1_arg0, "statsetbyname rankxp " .. maxXp - 1)
-					Engine.ExecNow(f1_arg0, "statsetbyname rank " .. f1_arg1.value)
+					Engine.ExecNow(f1_arg0, "statsetbyname plevel " .. newPrestige)
+					Engine.ExecNow(f1_arg0, "statsetbyname hasprestiged " .. (newPrestige > 0 and 1 or 0))
 					Engine.Exec(f1_arg0, "uploadstats " .. tostring(Engine.CurrentSessionMode()))
 				end)
 		},
@@ -258,16 +265,70 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 
 	table.insert(optionsTable, {
 		models = {
-			name = "Prestige",
+			name = "Rank Level",
 			desc = "",
 			image = nil,
-			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_prestige", prestigeTable,
-				CoD.PrestigeUtility.GetCurrentPLevel(controller), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
+			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_level", rankObjs,
+				CoD.BlackMarketUtility.GetCurrentRank(controller), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
 					UpdateInfoModels(f1_arg1)
-					local newPrestige = f1_arg1.value
-					Engine.ExecNow(f1_arg0, "statsetbyname plevel " .. newPrestige)
-					Engine.ExecNow(f1_arg0, "statsetbyname hasprestiged " .. (newPrestige > 0 and 1 or 0))
-					Engine.Exec(f1_arg0, "uploadstats " .. tostring(Engine.CurrentSessionMode()))
+					local rankTable = nil
+					local rank = f1_arg1.value + 1
+					if currentPrestige <= 10 then
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+							rankTable = "gamedata/tables/mp/mp_ranktable.csv"
+						elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+							rankTable = "gamedata/tables/zm/zm_ranktable.csv"
+						end
+						local skipLines = Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER and 3 or 2
+						local maxXp = tonumber(Engine.TableLookupGetColumnValueForRow(rankTable, rank - 2 + skipLines, 7))
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+							if maxXp ~= nil and rank == maxlevel then
+								maxXp = maxXp + 55600
+							end
+						end
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+							if maxXp ~= nil and rank == maxlevel then
+								maxXp = maxXp + 54244
+							end
+						end
+						if maxXp == nil then
+							maxXp = 0
+						end
+						Engine.ExecNow(f1_arg0, "statsetbyname rank " .. rank - 1 )
+						Engine.ExecNow(f1_arg0, "statsetbyname rankxp " .. maxXp )
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. 0 )
+					else
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+							rankTable = "gamedata/tables/mp/mp_paragonranktable.csv"
+						elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+							rankTable = "gamedata/tables/zm/zm_paragonranktable.csv"
+						end
+						local skipLines = 2
+						local maxXp = 0
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
+							maxXp = tonumber(Engine.TableLookupGetColumnValueForRow(rankTable, rank - 57 + skipLines, 7))
+							if maxXp ~= nil and rank == maxlevel then
+								maxXp = maxXp + 55600
+							end
+							rank = rank - 55
+						end
+						if Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
+							maxXp = tonumber(Engine.TableLookupGetColumnValueForRow(rankTable, rank - 37 + skipLines, 7))
+							if maxXp ~= nil and rank == maxlevel then
+								maxXp = maxXp + 54244
+							end
+							rank = rank - 35
+						end
+						if maxXp == nil then
+							maxXp = 0
+						end
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rank  " .. rank - 1 )
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. maxXp )
+					end
+						Engine.Exec(f1_arg0, "uploadstats " .. tostring(Engine.CurrentSessionMode()))
+						Engine.Exec(f1_arg0, "savegamerprofilestats")
+						
+						currentRank = rank
 				end)
 		},
 		properties = {
@@ -300,8 +361,7 @@ LUI.createMenu.BoiiiStatsMenu = function(controller)
 	GameSettingsBackground:setLeftRight(true, true, 0, 0)
 	GameSettingsBackground:setTopBottom(true, true, 0, 0)
 	GameSettingsBackground.MenuFrame.titleLabel:setText(Engine.Localize("STATS SETTINGS"))
-	GameSettingsBackground.MenuFrame.cac3dTitleIntermediary0.FE3dTitleContainer0.MenuTitle.TextBox1.Label0:setText(Engine
-		.Localize("STATS SETTINGS"))
+	GameSettingsBackground.MenuFrame.cac3dTitleIntermediary0.FE3dTitleContainer0.MenuTitle.TextBox1.Label0:setText(Engine.Localize("STATS SETTINGS"))
 	GameSettingsBackground.GameSettingsSelectedItemInfo.GameModeInfo:setAlpha(0)
 	GameSettingsBackground.GameSettingsSelectedItemInfo.GameModeName:setAlpha(0)
 	self:addElement(GameSettingsBackground)

--- a/data/ui_scripts/stats/__init__.lua
+++ b/data/ui_scripts/stats/__init__.lua
@@ -132,7 +132,7 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 						value = 1
 					},
 				}, nil, updateDvar))
-	end			
+	end
 	if Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
 		table.insert(optionsTable,
 			CoD.OptionsUtility.CreateDvarSettings(controller, "Unlock Easter Eggs",
@@ -155,7 +155,7 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 	local hasDefault = true
 	local currentPrestige = CoD.PrestigeUtility.GetCurrentPLevel(controller, Engine.CurrentSessionMode())
 	local currentRank = CoD.BlackMarketUtility.GetCurrentRank(controller) + 1
-	
+
 	local isMasterPrestige = currentPrestige == 11
 
 	if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
@@ -164,7 +164,6 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 		else
 			rankLevels = { 56, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 }
 		end
-			
 	elseif Engine.CurrentSessionMode() == Enum.eModes.MODE_ZOMBIES then
 		if not isMasterPrestige then
 			rankLevels = { 1, 5, 10, 15, 20, 25, 30, 35 }
@@ -182,13 +181,14 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 			value = value - 1,
 			default = value == currentRank,
 			title = "Rank Level",
-			desc = value~=currentRank and "" or "Current Rank"
+			desc = value ~= currentRank and "" or "Current Rank"
 		})
 	end
 
 	if hasDefault and currentRank ~= minlevel and currentRank < maxlevel and not isMasterPrestige then
 		table.insert(rankObjs, {
-			name = "Current: " .. tostring(currentRank <= minlevel and "Min" or currentRank >= maxlevel and "Max" or currentRank),
+			name = "Current: " ..
+			tostring(currentRank <= minlevel and "Min" or currentRank >= maxlevel and "Max" or currentRank),
 			value = currentRank - 1,
 			default = true,
 			title = "Rank Level",
@@ -199,7 +199,7 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 	local prestigeTable = {}
 	for i = 0, 11 do
 		table.insert(prestigeTable, {
-			name = i == 0 and "None" or i==11 and "Master" or i,
+			name = i == 0 and "None" or i == 11 and "Master" or i,
 			value = i,
 			default = i == currentPrestige,
 			title = "Prestige",
@@ -246,11 +246,12 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 			desc = "",
 			image = nil,
 			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_prestige", prestigeTable,
-				CoD.PrestigeUtility.GetCurrentPLevel(controller, Engine.CurrentSessionMode()), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
+				CoD.PrestigeUtility.GetCurrentPLevel(controller, Engine.CurrentSessionMode()), false,
+				function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
 					UpdateInfoModels(f1_arg1)
 					local newPrestige = f1_arg1.value
-					if newPrestige == 11 then 
-						Engine.Exec( f1_arg0, "PrestigeStatsMaster " .. tostring( Engine.CurrentSessionMode() ) )
+					if newPrestige == 11 then
+						Engine.Exec(f1_arg0, "PrestigeStatsMaster " .. tostring(Engine.CurrentSessionMode()))
 					end
 					Engine.ExecNow(f1_arg0, "statsetbyname plevel " .. newPrestige)
 					Engine.ExecNow(f1_arg0, "statsetbyname hasprestiged " .. (newPrestige > 0 and 1 or 0))
@@ -269,7 +270,8 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 			desc = "",
 			image = nil,
 			optionsDatasource = createSettingsDatasource(controller, "MPStatsSettings_rank_level", rankObjs,
-				CoD.BlackMarketUtility.GetCurrentRank(controller), false, function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
+				CoD.BlackMarketUtility.GetCurrentRank(controller), false,
+				function(f1_arg0, f1_arg1, f1_arg2, dvarName, f1_arg4)
 					UpdateInfoModels(f1_arg1)
 					local rankTable = nil
 					local rank = f1_arg1.value + 1
@@ -294,9 +296,9 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 						if maxXp == nil then
 							maxXp = 0
 						end
-						Engine.ExecNow(f1_arg0, "statsetbyname rank " .. rank - 1 )
-						Engine.ExecNow(f1_arg0, "statsetbyname rankxp " .. maxXp )
-						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. 0 )
+						Engine.ExecNow(f1_arg0, "statsetbyname rank " .. rank - 1)
+						Engine.ExecNow(f1_arg0, "statsetbyname rankxp " .. maxXp)
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. 0)
 					else
 						if Engine.CurrentSessionMode() == Enum.eModes.MODE_MULTIPLAYER then
 							rankTable = "gamedata/tables/mp/mp_paragonranktable.csv"
@@ -322,13 +324,12 @@ DataSources.MPStatsSettings = DataSourceHelpers.ListSetup("MPStatsSettings", fun
 						if maxXp == nil then
 							maxXp = 0
 						end
-						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rank  " .. rank - 1 )
-						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. maxXp )
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rank  " .. rank - 1)
+						Engine.ExecNow(f1_arg0, "statsetbyname paragon_rankxp " .. maxXp)
 					end
-						Engine.Exec(f1_arg0, "uploadstats " .. tostring(Engine.CurrentSessionMode()))
-						Engine.Exec(f1_arg0, "savegamerprofilestats")
-						
-						currentRank = rank
+					Engine.Exec(f1_arg0, "uploadstats " .. tostring(Engine.CurrentSessionMode()))
+
+					currentRank = rank
 				end)
 		},
 		properties = {
@@ -361,7 +362,8 @@ LUI.createMenu.BoiiiStatsMenu = function(controller)
 	GameSettingsBackground:setLeftRight(true, true, 0, 0)
 	GameSettingsBackground:setTopBottom(true, true, 0, 0)
 	GameSettingsBackground.MenuFrame.titleLabel:setText(Engine.Localize("STATS SETTINGS"))
-	GameSettingsBackground.MenuFrame.cac3dTitleIntermediary0.FE3dTitleContainer0.MenuTitle.TextBox1.Label0:setText(Engine.Localize("STATS SETTINGS"))
+	GameSettingsBackground.MenuFrame.cac3dTitleIntermediary0.FE3dTitleContainer0.MenuTitle.TextBox1.Label0:setText(
+	Engine.Localize("STATS SETTINGS"))
 	GameSettingsBackground.GameSettingsSelectedItemInfo.GameModeInfo:setAlpha(0)
 	GameSettingsBackground.GameSettingsSelectedItemInfo.GameModeName:setAlpha(0)
 	self:addElement(GameSettingsBackground)


### PR DESCRIPTION
- added a toggle to unlock all easter eggs
- players can adjust rank within the Master Prestige up to level 1000.
- setting rank now sets you directly on the rank you choose. No more 1xp to the next level.
- setting level to max now lets you prestige right away.

![menu](https://github.com/momo5502/boiii/assets/122710241/e9f405a4-d433-440b-ad48-56160206e871)
