### PR TITLE
fix(server_status): format it properly

### DIFF
--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -44,9 +44,6 @@ namespace patches
 	{
 		void post_unpack() override
 		{
-			// print hexadecimal xuids in status command
-			utils::hook::copy_string(game::select(0x143050560, 0x140E85B00), "%12llx ");
-
 			// print hexadecimal xuids in chat game log command
 			utils::hook::set<char>(game::select(0x142FD9362, 0x140E16FA2), 'x');
 

--- a/src/client/component/status.cpp
+++ b/src/client/component/status.cpp
@@ -37,7 +37,7 @@ namespace status
 			utils::hook::call(game::select(0x142246EDE, 0x14052C5CE), print_client_xuid);
 
 			utils::hook::copy_string(game::select(0x143050480, 0x140E85A20),
-			                         "num score ping guid             name             address                  qport  \n");
+			                         "num score ping xuid             name             address                  qport  \n");
 			utils::hook::copy_string(game::select(0x1430504E0, 0x140E85A80),
 			                         "--- ----- ---- ---------------- ---------------- ------------------------ ------ \n");
 		}

--- a/src/client/component/status.cpp
+++ b/src/client/component/status.cpp
@@ -1,0 +1,47 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+#include <game/game.hpp>
+
+#include <utils/hook.hpp>
+
+namespace status
+{
+	namespace
+	{
+		int client_num_;
+
+		void print_client_num(int channel, int label, const char* fmt, const int client_num)
+		{
+			client_num_ = client_num;
+			game::Com_Printf(channel, label, fmt, client_num);
+		}
+
+		void print_client_xuid(int channel, int label, [[maybe_unused]] const char* fmt, const uint64_t xuid)
+		{
+			if (game::SV_IsTestClient(client_num_))
+			{
+				game::Com_Printf(channel, label, "%16s ", "bot0");
+				return;
+			}
+
+			game::Com_Printf(channel, label, "%12llx ", xuid);
+		}
+	}
+
+	struct component final : generic_component
+	{
+		void post_unpack() override
+		{
+			// Patch the status command for test clients
+			utils::hook::call(game::select(0x142246E37, 0x14052C527), print_client_num);
+			utils::hook::call(game::select(0x142246EDE, 0x14052C5CE), print_client_xuid);
+
+			utils::hook::copy_string(game::select(0x143050480, 0x140E85A20),
+			                         "num score ping xuid             name             address                  qport  \n");
+			utils::hook::copy_string(game::select(0x1430504E0, 0x140E85A80),
+			                         "--- ----- ---- ---------------- ---------------- ------------------------ ------ \n");
+		}
+	};
+}
+
+REGISTER_COMPONENT(status::component)

--- a/src/client/component/status.cpp
+++ b/src/client/component/status.cpp
@@ -8,7 +8,7 @@ namespace status
 {
 	namespace
 	{
-		int client_num_;
+		thread_local int client_num_;
 
 		void print_client_num(int channel, int label, const char* fmt, const int client_num)
 		{

--- a/src/client/component/status.cpp
+++ b/src/client/component/status.cpp
@@ -37,7 +37,7 @@ namespace status
 			utils::hook::call(game::select(0x142246EDE, 0x14052C5CE), print_client_xuid);
 
 			utils::hook::copy_string(game::select(0x143050480, 0x140E85A20),
-			                         "num score ping xuid             name             address                  qport  \n");
+			                         "num score ping guid             name             address                  qport  \n");
 			utils::hook::copy_string(game::select(0x1430504E0, 0x140E85A80),
 			                         "--- ----- ---- ---------------- ---------------- ------------------------ ------ \n");
 		}


### PR DESCRIPTION
bot0 required for consistency between our clients and plutonium as the bot's guid is usually bot%d (%d replaced by qport)
This is not possible currently so just like I've done on plutonium t5 it's just bot0
Then i fixed the status header