### PR TITLE
load our scripts sooner

### DIFF
--- a/src/client/component/script.cpp
+++ b/src/client/component/script.cpp
@@ -159,14 +159,12 @@ namespace script
 
 		void begin_load_scripts_stub(game::scriptInstance_t inst, int user)
 		{
-			if (!game::Com_IsInGame() || game::Com_IsRunningUILevel())
-			{
-				game::Scr_BeginLoadScripts(inst, user);
-				return;
-			}
-
 			game::Scr_BeginLoadScripts(inst, user);
-			load_scripts();
+
+			if (game::Com_IsInGame() && !game::Com_IsRunningUILevel())
+			{
+				load_scripts();
+			}
 		}
 
 		int server_script_checksum_stub()

--- a/src/client/component/script.cpp
+++ b/src/client/component/script.cpp
@@ -157,15 +157,15 @@ namespace script
 			allocator.clear();
 		}
 
-		void load_gametype_script_stub()
+		void begin_load_scripts_stub(game::scriptInstance_t inst, int user)
 		{
 			if (!game::Com_IsInGame() || game::Com_IsRunningUILevel())
 			{
-				game::GScr_LoadGametypeScript();
+				game::Scr_BeginLoadScripts(inst, user);
 				return;
 			}
 
-			game::GScr_LoadGametypeScript();
+			game::Scr_BeginLoadScripts(inst, user);
 			load_scripts();
 		}
 
@@ -191,8 +191,8 @@ namespace script
 			// Free our scripts when the game ends
 			game_event::on_g_shutdown_game(clear_script_memory);
 
-			// Load our scripts when the gametype script is loaded
-			utils::hook::call(game::select(0x141AAF37C, 0x1402D8C7F), load_gametype_script_stub);
+			// Load our custom/overriding scripts
+			utils::hook::call(game::select(0x141AAE92F, 0x1402D81FF), begin_load_scripts_stub);
 
 			// Force GSC checksums to be valid
 			utils::hook::call(game::select(0x1408F2E5D, 0x1400E2D22), server_script_checksum_stub);

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -195,6 +195,7 @@ namespace game
 	};
 	WEAK symbol<unsigned int(scriptInstance_t inst)> Scr_GetNumParam{0x0, 0x140171320};
 	WEAK symbol<unsigned int(scriptInstance_t inst, const char* filename)> Scr_LoadScript{0x1412C83F0, 0x140156610};
+	WEAK symbol<void(scriptInstance_t inst, int user)> Scr_BeginLoadScripts{0x1412C7DF0, 0x140156010};
 
 	WEAK symbol<void(const char* name, const char* key, unsigned int playbackFlags, float volume, void* callbackInfo,
 	                 int id)> Cinematic_StartPlayback{0x1412BE3A0};
@@ -242,8 +243,6 @@ namespace game
 	WEAK symbol<void(char* dest, size_t destsize, const char* src)> I_strcpy{
 		0x1422E9410, 0x1405811E0
 	};
-
-	WEAK symbol<void()> GScr_LoadGametypeScript{0x141AAD850, 0x1402D7140};
 
 	// Variables
 	WEAK symbol<cmd_function_s> cmd_functions{0x15689DF58, 0x14946F860};


### PR DESCRIPTION
fixes a problem where bots weren't spawning in combat training (due to original _bot.gsc loading before our override?)
![image](https://github.com/momo5502/boiii/assets/64374267/6d56b0aa-7a5e-42db-96e7-9c457032a390)

using this patch, bots do indeed spawn again
![image](https://github.com/momo5502/boiii/assets/64374267/7e594ea4-a933-448b-9c0a-60cf486d53c5)
