### PR TITLE
Fix: typo causing missing team change button

### DIFF
--- a/data/ui_scripts/party/__init__.lua
+++ b/data/ui_scripts/party/__init__.lua
@@ -1,23 +1,14 @@
-local getModeInfo = function()
-	local id = Engine.GetLobbyUIScreen()
-	return LobbyData:UITargetFromId(id)
-end
-
-local getMaxClients = function()
-	local modeInfo = getModeInfo()
-	return modeInfo.maxClients
-end
+local modeInfo = LobbyData:UITargetFromId(Engine.GetLobbyUIScreen())
+local maxClients = modeInfo.maxClients
 
 -- Disable setting party privacy in menu. Auto set to open + max.
 Engine.SetDvar("partyprivacyenabled", 0)
 Engine.SetDvar("tu4_partyprivacyuseglobal", 0)
 Engine.SetDvar("tu4_partyprivacyluacheck", 0)
 
-local maxClients = getMaxClients()
-
 -- Fix for invisible bots in custom games
 if maxClients >= 1 then
-	return Engine.SetDvar("party_maxplayers", maxClients)
+	Engine.SetDvar("party_maxplayers", maxClients)
 end
 
 if not Engine.IsInGame() then


### PR DESCRIPTION
This little typo caused the script to return early causing the in-game team change button and zm restart level button to disappear. Whoopsies.